### PR TITLE
fix: More robust handling of newlines for chat completion LLM API

### DIFF
--- a/crates/asset-pipeline/web-components/streaming-chat.ts
+++ b/crates/asset-pipeline/web-components/streaming-chat.ts
@@ -36,7 +36,7 @@ export class StreamingChat extends HTMLElement {
             const { value, done } = await reader.read();
             if (done) break;
             let dataDone = false;
-            const arr = value.split('\n');
+            const arr = value.split(/\r?\n/);
             arr.forEach((data) => {
                 if (data.length === 0) return; // ignore empty message
                 if (data.startsWith(':')) return; // ignore sse comment message


### PR DESCRIPTION
This change also allows chat completion requests to contain the `\r` character from Windows.
You would normally not expect it, but it is more robust when optionally also splitting based on the carriage return.

The reason for this change is explained in more detail in #29.

